### PR TITLE
Skip length checks if base is nil

### DIFF
--- a/lib/clio/picture_extractor.rb
+++ b/lib/clio/picture_extractor.rb
@@ -112,7 +112,7 @@ class PictureExtractor < Component
 
     def ensure_fname_length(fname)
         base, ext = fname.scan(/^(.+)\.(\w+)$/).flatten
-        if base.length > MAXIMUM_FILENAME_LENGTH
+        if base and base.length > MAXIMUM_FILENAME_LENGTH
             base = base[0...MAXIMUM_FILENAME_LENGTH]
             "#{base}.#{ext}"
         else


### PR DESCRIPTION
Fix a crash when dereferencing nil object:

21 Mar 08:45:42 ERROR: Ошибка NoMethodError: undefined method `length' for nil:NilClass
    ./lib/clio/picture_extractor.rb:115:in`ensure_fname_length'
    ./lib/clio/picture_extractor.rb:73:in `block in extract_images!'
    ./lib/clio/core_ext.rb:89:in`block in each_with_progress'
    ./lib/clio/core_ext.rb:89:in `each'
    ./lib/clio/core_ext.rb:89:in`each_with_progress'
    ./lib/clio/picture_extractor.rb:61:in `extract_images!'
    ./lib/clio/picture_extractor.rb:7:in`run'
    ./lib/clio/feed_context.rb:41:in `extract_pictures!'
    ./lib/clio.rb:50:in`block in run!'
    ./lib/clio.rb:43:in `each'
    ./lib/clio.rb:43:in`run!'
    bin/clio.rb:59:in `<main>'
